### PR TITLE
Converted theme.js to export themeSwitcher function

### DIFF
--- a/App.js
+++ b/App.js
@@ -10,7 +10,7 @@ import themeSwitcher from './theme.js';
 const Tab = createBottomTabNavigator();
 
 export default function App() {
-  const theme = themeSwitcher('dark');
+  let theme = themeSwitcher('dark');
 
   return (
     <NavigationContainer style={styles.container} theme={theme}>

--- a/App.js
+++ b/App.js
@@ -5,11 +5,13 @@ import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { FontAwesome, Entypo } from "@expo/vector-icons";
 import HomeStackScreen from "./screen/home/HomeStackScreen";
 import ExploreScreen from "./screen/explore/ExploreScreen";
-import theme from './theme.js';
+import themeSwitcher from './theme.js';
 
 const Tab = createBottomTabNavigator();
 
 export default function App() {
+  const theme = themeSwitcher('dark');
+
   return (
     <NavigationContainer style={styles.container} theme={theme}>
       <Tab.Navigator>

--- a/theme.js
+++ b/theme.js
@@ -1,16 +1,25 @@
 import { useColorScheme } from "react-native";
 import { DefaultTheme, DarkTheme } from "@react-navigation/native";
 
-// const MyTheme = {
-//   dark: false,
-//   colors: {
-//     primary: 'rgb(255, 45, 85)',
-//     background: 'rgb(242, 242, 242)',
-//     card: 'rgb(255, 255, 255)',
-//     text: 'rgb(28, 28, 30)',
-//     border: 'rgb(199, 199, 204)',
-//     notification: 'rgb(255, 69, 58)',
-//   },
-// };
+const customTheme = {
+  dark: DarkTheme,
+  light: DefaultTheme,
+  sampleTheme: {
+    dark: false,
+    colors: {
+      primary: 'rgb(255, 45, 85)',
+      background: 'rgb(242, 242, 242)',
+      card: 'rgb(255, 255, 255)',
+      text: 'rgb(28, 28, 30)',
+      border: 'rgb(199, 199, 204)',
+      notification: 'rgb(255, 69, 58)',
+    },
+  },
+};
 
-export default DarkTheme;
+const themeSwitcher = (theme) => {
+  if (theme) { return customTheme[theme] };
+  if (!theme) { return DefaultTheme };
+}
+
+export default themeSwitcher;


### PR DESCRIPTION
I created a quick customTheme template and a themeSwitcher function to select a theme.

It is hardcoded in App.js to 'dark' at the moment, but if I (or whomever) have time later today to create some sort of toggle or selector, it should be fairly simple from there to switch between themes.

As long as it works on your devices, it should be good to merge with main. Only theme.js and App.js were modified.